### PR TITLE
Add draft pick history tracking and export

### DIFF
--- a/pages/draftboard.py
+++ b/pages/draftboard.py
@@ -82,5 +82,6 @@ def update_draft_board(timestamp, rows):
         # Update the board data and save it to CSV
         updated_board = pd.DataFrame(rows)
         helpers.save_board(updated_board)
+        helpers.log_draft_picks(updated_board)
         return updated_board.to_dict('records')
     return dash.no_update

--- a/pages/history.py
+++ b/pages/history.py
@@ -1,0 +1,28 @@
+import dash
+from dash import html, dcc
+import plotly.express as px
+from utility import helpers
+
+
+dash.register_page(__name__, path='/history')
+
+
+def layout():
+    df = helpers.get_draft_history()
+    if df.empty:
+        return html.Div([
+            html.H1('Draft History'),
+            html.P('No draft picks have been logged yet.')
+        ])
+
+    picks_per_owner = df.groupby('owner').size().reset_index(name='picks')
+    spend_per_owner = df.groupby('owner')['price'].sum().reset_index(name='spent')
+
+    fig1 = px.bar(picks_per_owner, x='owner', y='picks', title='Draft Picks by Owner')
+    fig2 = px.bar(spend_per_owner, x='owner', y='spent', title='Total Spend by Owner')
+
+    return html.Div([
+        html.H1('Draft History'),
+        dcc.Graph(figure=fig1),
+        dcc.Graph(figure=fig2)
+    ])

--- a/utility/excel.py
+++ b/utility/excel.py
@@ -3,10 +3,12 @@ from openpyxl.utils.dataframe import dataframe_to_rows
 from openpyxl.styles import Font, Alignment, PatternFill
 import pandas as pd
 import numpy as np
+import sqlite3
+from utility import helpers
 
 positions = ['QB', 'RB', 'WR', 'TE']
 
-# Function to save data to Excel (same as before)
+
 def save_to_excel(position_dfs, filename='fantasy_football_auction_values.xlsx'):
     wb = Workbook()
     wb.remove(wb.active)  # Remove the default sheet
@@ -14,16 +16,13 @@ def save_to_excel(position_dfs, filename='fantasy_football_auction_values.xlsx')
     for pos in positions:
         ws = wb.create_sheet(pos)
         df = position_dfs[pos][['Name', 'Team', 'ModelPoints', 'VORP', 'AuctionValue']]
-        
-        # Add headers
+
         headers = ['Rank'] + list(df.columns)
         ws.append(headers)
 
-        # Add data
         for i, row in enumerate(dataframe_to_rows(df, index=False, header=False), start=2):
-            ws.append([i-1] + list(row))
+            ws.append([i - 1] + list(row))
 
-        # Format the worksheet
         for cell in ws[1]:
             cell.font = Font(bold=True)
             cell.fill = PatternFill(start_color="CCCCCC", end_color="CCCCCC", fill_type="solid")
@@ -32,34 +31,35 @@ def save_to_excel(position_dfs, filename='fantasy_football_auction_values.xlsx')
             for cell in row:
                 cell.alignment = Alignment(horizontal='center')
 
-        # Adjust column widths
         for column in ws.columns:
             max_length = 0
-            column = [cell for cell in column]
-            for cell in column:
+            column_cells = [cell for cell in column]
+            for cell in column_cells:
                 try:
                     if len(str(cell.value)) > max_length:
                         max_length = len(cell.value)
-                except:
+                except Exception:
                     pass
-            adjusted_width = (max_length + 2)
-            ws.column_dimensions[column[0].column_letter].width = adjusted_width
+            ws.column_dimensions[column_cells[0].column_letter].width = max_length + 2
 
-    # Create a summary sheet
     ws_summary = wb.create_sheet('Summary', 0)
     summary_data = []
     for pos in positions:
         top_players = position_dfs[pos].head(10)
-        summary_data.extend(top_players[['Name', 'Position', 'Team', 'ModelPoints', 'VORP', 'AuctionValue']].values.tolist())
-    
-    summary_df = pd.DataFrame(summary_data, columns=['Name', 'Position', 'Team', 'ModelPoints', 'VORP', 'AuctionValue'])
+        summary_data.extend(
+            top_players[['Name', 'Position', 'Team', 'ModelPoints', 'VORP', 'AuctionValue']].values.tolist()
+        )
+
+    summary_df = pd.DataFrame(
+        summary_data,
+        columns=['Name', 'Position', 'Team', 'ModelPoints', 'VORP', 'AuctionValue']
+    )
     summary_df = summary_df.sort_values('AuctionValue', ascending=False)
-    
+
     ws_summary.append(['Rank'] + list(summary_df.columns))
     for i, row in enumerate(dataframe_to_rows(summary_df, index=False, header=False), start=2):
-        ws_summary.append([i-1] + list(row))
+        ws_summary.append([i - 1] + list(row))
 
-    # Format the summary worksheet
     for cell in ws_summary[1]:
         cell.font = Font(bold=True)
         cell.fill = PatternFill(start_color="CCCCCC", end_color="CCCCCC", fill_type="solid")
@@ -68,18 +68,24 @@ def save_to_excel(position_dfs, filename='fantasy_football_auction_values.xlsx')
         for cell in row:
             cell.alignment = Alignment(horizontal='center')
 
-    # Adjust column widths for summary sheet
     for column in ws_summary.columns:
         max_length = 0
-        column = [cell for cell in column]
-        for cell in column:
+        column_cells = [cell for cell in column]
+        for cell in column_cells:
             try:
                 if len(str(cell.value)) > max_length:
                     max_length = len(cell.value)
-            except:
+            except Exception:
                 pass
-        adjusted_width = (max_length + 2)
-        ws_summary.column_dimensions[column[0].column_letter].width = adjusted_width
+        ws_summary.column_dimensions[column_cells[0].column_letter].width = max_length + 2
 
     wb.save(filename)
     print(f"Excel file '{filename}' has been created successfully.")
+
+
+def export_draft_history(filename='draft_history.xlsx'):
+    conn = sqlite3.connect(helpers.DB_FILE)
+    df = pd.read_sql_query('SELECT * FROM draft_picks', conn)
+    conn.close()
+    df.to_excel(filename, index=False)
+    print(f"Draft history exported to {filename}")

--- a/utility/helpers.py
+++ b/utility/helpers.py
@@ -1,5 +1,33 @@
 import pandas as pd
+import sqlite3
+from datetime import datetime
+from pathlib import Path
 from utility import scoring
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DB_FILE = str(BASE_DIR / 'data' / 'draft_history.db')
+CURRENT_SEASON = datetime.now().year
+
+
+def init_db():
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS draft_picks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL,
+            season INTEGER NOT NULL,
+            player TEXT,
+            position TEXT,
+            team TEXT,
+            owner TEXT,
+            price REAL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
 
 def get_schedule():
     file_path = '/Users/justin/Desktop/chest/fantasy_football/2025/assets/schedule_2025.csv'
@@ -140,3 +168,45 @@ def get_position_data(pos: str):
         print("no data")
         df = pd.DataFrame()
     return df
+
+
+def log_draft_picks(df: pd.DataFrame, season: int = CURRENT_SEASON):
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    for _, row in df.iterrows():
+        owner = str(row.get('Owner', '')).strip()
+        if owner:
+            cur.execute(
+                'SELECT 1 FROM draft_picks WHERE season=? AND player=?',
+                (season, row['Name'])
+            )
+            if not cur.fetchone():
+                cur.execute(
+                    'INSERT INTO draft_picks(timestamp, season, player, position, team, owner, price) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                    (
+                        datetime.utcnow().isoformat(),
+                        season,
+                        row['Name'],
+                        row.get('Position'),
+                        row.get('Team'),
+                        owner,
+                        float(row.get('Price', 0))
+                    )
+                )
+    conn.commit()
+    conn.close()
+
+
+def get_draft_history(season: int = None):
+    conn = sqlite3.connect(DB_FILE)
+    query = 'SELECT * FROM draft_picks'
+    params = ()
+    if season is not None:
+        query += ' WHERE season=?'
+        params = (season,)
+    df = pd.read_sql_query(query, conn, params=params)
+    conn.close()
+    return df
+
+
+init_db()


### PR DESCRIPTION
## Summary
- log each draft pick to a SQLite `draft_picks` table with timestamp and season
- add `/history` page with Plotly graphs of picks and spending
- provide Excel export for draft history

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2576dacd88322ab5711bb3ca8555f