### PR TITLE
Use AgGrid client-side filtering with responsive height

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,7 +147,7 @@ draft_history = []
 app = dash.Dash(__name__, use_pages=True, title='FF', update_title='****', suppress_callback_exceptions=True, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-app.layout = create_layout(all_players_sorted['Name'].tolist(), positions, NUM_TEAMS)
+app.layout = create_layout(all_players_sorted['Name'].tolist(), NUM_TEAMS)
 
 @app.callback(
     [Output('player-table', 'rowData'),
@@ -158,9 +158,7 @@ app.layout = create_layout(all_players_sorted['Name'].tolist(), positions, NUM_T
     [Output(f'team-{i}-summary', 'children') for i in range(1, NUM_TEAMS + 1)] +
     [Output(f'team-{i}-remaining-budget', 'children') for i in range(1, NUM_TEAMS + 1)] +
     [Output(f'team-{i}-composition-chart', 'figure') for i in range(1, NUM_TEAMS + 1)],
-    [Input('position-filter', 'value'),
-     Input('search-input', 'value'),
-     Input('draft-button', 'n_clicks'),
+    [Input('draft-button', 'n_clicks'),
      Input('undo-button', 'n_clicks'),
      Input('pass-yds-pt', 'value'),
      Input('pass-td-pts', 'value'),
@@ -175,7 +173,7 @@ app.layout = create_layout(all_players_sorted['Name'].tolist(), positions, NUM_T
      State('draft-team', 'value'),
      State('draft-price', 'value')]
 )
-def update_data(position, search, draft_clicks, undo_clicks,
+def update_data(draft_clicks, undo_clicks,
                 pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_pts, fum_pen,
                 rec_yds_pt, rec_per, rec_td_pts,
                 draft_name, draft_team, draft_price):
@@ -233,10 +231,6 @@ def update_data(position, search, draft_clicks, undo_clicks,
         all_players_sorted.loc[all_players_sorted['Name'] == last_draft[0], 'PricePaid'] = 0
 
     filtered_df = all_players_sorted
-    if position != 'All':
-        filtered_df = filtered_df[filtered_df['Position'] == position]
-    if search:
-        filtered_df = filtered_df[filtered_df['Name'].str.contains(search, case=False)]
 
     value_dist = px.box(filtered_df, x='Position', y='AuctionValue', title='Auction Value Distribution by Position')
     top_players = px.bar(filtered_df.head(20), x='Name', y='AuctionValue', color='Position', title='Top 20 Players by Auction Value')

--- a/layout.py
+++ b/layout.py
@@ -2,21 +2,6 @@ from dash_ag_grid import AgGrid
 import dash_bootstrap_components as dbc
 from dash import html, dcc
 
-def create_filters(positions):
-    return dbc.Row([
-        dbc.Col([
-            dcc.Dropdown(
-                id='position-filter',
-                options=[{'label': pos, 'value': pos} for pos in positions] + [{'label': 'All', 'value': 'All'}],
-                value='All',
-                placeholder="Select Position"
-            )
-        ], width=3),
-        dbc.Col([
-            dcc.Input(id='search-input', type='text', placeholder='Search players...', className="form-control")
-        ], width=3)
-    ], className="mb-4")
-
 def create_scoring_controls():
     return dbc.Row([
         dbc.Col([
@@ -97,9 +82,9 @@ def create_player_table():
         ],
         rowData=[],
         defaultColDef={"resizable": True, "filter": True, "sortable": True},
-        dashGridOptions={"pagination": True, "paginationAutoPageSize": True},
+        dashGridOptions={"pagination": True, "paginationAutoPageSize": True, "rowBuffer": 0},
         className="ag-theme-alpine",
-        style={"height": 1600}
+        style={"height": "70vh"}
     )
 
 def create_draft_summary():
@@ -129,11 +114,10 @@ def create_graphs():
         dcc.Graph(id='top-players-graph')
     ])
 
-def create_layout(players, positions, teams):
+def create_layout(players, teams):
     return dbc.Container([
         html.H1("Fantasy Football Draft Dashboard", className="my-4"),
         create_scoring_controls(),
-        create_filters(positions),
         create_draft_input(players, teams),
         dbc.Row([
             dbc.Col(create_player_table(), width=12),


### PR DESCRIPTION
## Summary
- Make AgGrid responsive with 70vh height and enable row virtualization
- Drop server-side filtering inputs to rely on client-side pagination and filtering

## Testing
- `python -m py_compile layout.py app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2667d5fe0832287fb60bc6a68eb37