### PR TITLE
Use dcc.Store for player data and streamline callbacks

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,41 +147,30 @@ draft_history = []
 app = dash.Dash(__name__, use_pages=True, title='FF', update_title='****', suppress_callback_exceptions=True, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-app.layout = create_layout(all_players_sorted['Name'].tolist(), positions, NUM_TEAMS)
+app.layout = create_layout(
+    all_players_sorted['Name'].tolist(),
+    NUM_TEAMS,
+    all_players_sorted.to_dict('records'),
+)
+
 
 @app.callback(
-    [Output('player-table', 'rowData'),
-     Output('value-distribution-graph', 'figure'),
-     Output('top-players-graph', 'figure'),
-     Output('draft-message', 'children'),
-     Output('draft-summary', 'children')] +
-    [Output(f'team-{i}-summary', 'children') for i in range(1, NUM_TEAMS + 1)] +
-    [Output(f'team-{i}-remaining-budget', 'children') for i in range(1, NUM_TEAMS + 1)] +
-    [Output(f'team-{i}-composition-chart', 'figure') for i in range(1, NUM_TEAMS + 1)],
-    [Input('position-filter', 'value'),
-     Input('search-input', 'value'),
-     Input('draft-button', 'n_clicks'),
-     Input('undo-button', 'n_clicks'),
-     Input('pass-yds-pt', 'value'),
-     Input('pass-td-pts', 'value'),
-     Input('int-pen', 'value'),
-     Input('rush-yds-pt', 'value'),
-     Input('rush-td-pts', 'value'),
-     Input('fum-pen', 'value'),
-     Input('rec-yds-pt', 'value'),
-     Input('rec-per', 'value'),
-     Input('rec-td-pts', 'value')],
-    [State('draft-name', 'value'),
-     State('draft-team', 'value'),
-     State('draft-price', 'value')]
+    Output('player-data', 'data'),
+    [
+        Input('pass-yds-pt', 'value'),
+        Input('pass-td-pts', 'value'),
+        Input('int-pen', 'value'),
+        Input('rush-yds-pt', 'value'),
+        Input('rush-td-pts', 'value'),
+        Input('fum-pen', 'value'),
+        Input('rec-yds-pt', 'value'),
+        Input('rec-per', 'value'),
+        Input('rec-td-pts', 'value'),
+    ],
+    State('player-data', 'data'),
 )
-def update_data(position, search, draft_clicks, undo_clicks,
-                pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_pts, fum_pen,
-                rec_yds_pt, rec_per, rec_td_pts,
-                draft_name, draft_team, draft_price):
-    ctx = dash.callback_context
-    global all_players_sorted, draft_history
-
+def update_player_data(pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_pts,
+                       fum_pen, rec_yds_pt, rec_per, rec_td_pts, current_data):
     config = {
         'QB': {
             'PassYds': {'points_per': pass_yds_pt, 'bonuses': scoring.QB_SCORING_DEFAULT['PassYds']['bonuses']},
@@ -207,49 +196,75 @@ def update_data(position, search, draft_clicks, undo_clicks,
             'Rec': {'points_per': rec_per, 'bonuses': scoring.TE_SCORING_DEFAULT['Rec']['bonuses']},
             'RecTD': {'points': rec_td_pts},
             'Fum': {'points': fum_pen},
-        }
+        },
     }
-
     new_players = compute_values(config)
-    drafted_cols = all_players_sorted[['Name', 'Drafted', 'DraftedBy', 'PricePaid']]
-    new_players = new_players.merge(drafted_cols, on='Name', how='left')
-    new_players['Drafted'] = new_players['Drafted'].fillna(False)
-    new_players['DraftedBy'] = new_players['DraftedBy'].fillna('')
-    new_players['PricePaid'] = new_players['PricePaid'].fillna(0)
-    all_players_sorted = new_players
+    if current_data:
+        drafted_cols = pd.DataFrame(current_data)[['Name', 'Drafted', 'DraftedBy', 'PricePaid']]
+        new_players = new_players.merge(drafted_cols, on='Name', how='left')
+        new_players['Drafted'] = new_players['Drafted'].fillna(False)
+        new_players['DraftedBy'] = new_players['DraftedBy'].fillna('')
+        new_players['PricePaid'] = new_players['PricePaid'].fillna(0)
+    else:
+        new_players['Drafted'] = False
+        new_players['DraftedBy'] = ''
+        new_players['PricePaid'] = 0
+    return new_players.to_dict('records')
 
+
+@app.callback(
+    Output('player-data', 'data'),
+    [Input('draft-button', 'n_clicks'),
+     Input('undo-button', 'n_clicks')],
+    [State('draft-name', 'value'),
+     State('draft-team', 'value'),
+     State('draft-price', 'value'),
+     State('player-data', 'data')],
+    prevent_initial_call=True,
+)
+def update_draft(draft_clicks, undo_clicks, draft_name, draft_team, draft_price, data):
+    ctx = dash.callback_context
+    if data is None:
+        raise dash.exceptions.PreventUpdate
+    df = pd.DataFrame(data)
     if ctx.triggered and ctx.triggered[0]['prop_id'] == 'draft-button.n_clicks':
         if draft_name and draft_team and draft_price is not None:
-            player = all_players_sorted[all_players_sorted['Name'] == draft_name]
-            if not player.empty and not player['Drafted'].iloc[0]:
+            player = df[df['Name'] == draft_name]
+            if not player.empty and not player.iloc[0]['Drafted']:
                 draft_history.append((draft_name, draft_team, draft_price))
-                all_players_sorted.loc[all_players_sorted['Name'] == draft_name, 'Drafted'] = True
-                all_players_sorted.loc[all_players_sorted['Name'] == draft_name, 'DraftedBy'] = draft_team
-                all_players_sorted.loc[all_players_sorted['Name'] == draft_name, 'PricePaid'] = draft_price
+                df.loc[df['Name'] == draft_name, ['Drafted', 'DraftedBy', 'PricePaid']] = [True, draft_team, draft_price]
     elif ctx.triggered and ctx.triggered[0]['prop_id'] == 'undo-button.n_clicks' and draft_history:
         last_draft = draft_history.pop()
-        all_players_sorted.loc[all_players_sorted['Name'] == last_draft[0], 'Drafted'] = False
-        all_players_sorted.loc[all_players_sorted['Name'] == last_draft[0], 'DraftedBy'] = ''
-        all_players_sorted.loc[all_players_sorted['Name'] == last_draft[0], 'PricePaid'] = 0
+        df.loc[df['Name'] == last_draft[0], ['Drafted', 'DraftedBy', 'PricePaid']] = [False, '', 0]
+    return df.to_dict('records')
 
-    filtered_df = all_players_sorted
-    if position != 'All':
-        filtered_df = filtered_df[filtered_df['Position'] == position]
-    if search:
-        filtered_df = filtered_df[filtered_df['Name'].str.contains(search, case=False)]
 
-    value_dist = px.box(filtered_df, x='Position', y='AuctionValue', title='Auction Value Distribution by Position')
-    top_players = px.bar(filtered_df.head(20), x='Name', y='AuctionValue', color='Position', title='Top 20 Players by Auction Value')
+@app.callback(Output('player-table', 'rowData'), Input('player-data', 'data'))
+def update_table(data):
+    return data or []
+
+
+@app.callback(
+    [Output('value-distribution-graph', 'figure'),
+     Output('top-players-graph', 'figure'),
+     Output('draft-summary', 'children')] +
+    [Output(f'team-{i}-summary', 'children') for i in range(1, NUM_TEAMS + 1)] +
+    [Output(f'team-{i}-remaining-budget', 'children') for i in range(1, NUM_TEAMS + 1)] +
+    [Output(f'team-{i}-composition-chart', 'figure') for i in range(1, NUM_TEAMS + 1)],
+    Input('player-data', 'data'),
+)
+def update_summaries(data):
+    df = pd.DataFrame(data or [])
+    value_dist = px.box(df, x='Position', y='AuctionValue', title='Auction Value Distribution by Position')
+    top_players = px.bar(df.head(20), x='Name', y='AuctionValue', color='Position', title='Top 20 Players by Auction Value')
     top_players.update_layout(xaxis={'categoryorder': 'total descending'})
-
-    drafted_players = all_players_sorted[all_players_sorted['Drafted']]
+    drafted_players = df[df['Drafted']]
     summary = [
         html.P(f"Total Players Drafted: {len(drafted_players)}"),
         html.P(f"Total Spend: ${drafted_players['PricePaid'].sum():.2f}"),
         html.P("Top Drafted Players:"),
-        html.Ul([html.Li(f"{row['Name']} - {row['DraftedBy']} - ${row['PricePaid']}") for _, row in drafted_players.sort_values('PricePaid', ascending=False).head(5).iterrows()])
+        html.Ul([html.Li(f"{row['Name']} - {row['DraftedBy']} - ${row['PricePaid']}") for _, row in drafted_players.sort_values('PricePaid', ascending=False).head(5).iterrows()]),
     ]
-
     team_summaries = []
     team_budgets = []
     team_charts = []
@@ -262,7 +277,7 @@ def update_data(position, search, draft_clicks, undo_clicks,
             html.P(f"Players Drafted: {len(team_players)}"),
             html.P(f"Total Spend: ${team_spend:.2f}"),
             html.P("Drafted Players:"),
-            html.Ul([html.Li(f"{row['Name']} ({row['Position']}) - ${row['PricePaid']}") for _, row in team_players.iterrows()])
+            html.Ul([html.Li(f"{row['Name']} ({row['Position']}) - ${row['PricePaid']}") for _, row in team_players.iterrows()]),
         ]
         team_summaries.append(team_summary)
         team_budgets.append(f"Remaining Budget: ${remaining_budget:.2f}")
@@ -270,9 +285,13 @@ def update_data(position, search, draft_clicks, undo_clicks,
         team_chart = go.Figure(data=[go.Pie(labels=position_counts.index, values=position_counts.values)])
         team_chart.update_layout(title=f"{team_name} Composition", height=300)
         team_charts.append(team_chart)
+    return value_dist, top_players, summary, *team_summaries, *team_budgets, *team_charts
 
-    return (filtered_df.to_dict('records'), value_dist, top_players, '', summary,
-            *team_summaries, *team_budgets, *team_charts)
+
+@app.callback(Output('player-table', 'dashGridOptions'), Input('search-input', 'value'))
+def update_quick_filter(text):
+    return {'pagination': True, 'paginationAutoPageSize': True, 'quickFilterText': text or ''}
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/layout.py
+++ b/layout.py
@@ -2,20 +2,20 @@ from dash_ag_grid import AgGrid
 import dash_bootstrap_components as dbc
 from dash import html, dcc
 
-def create_filters(positions):
+
+def create_filters():
+    """Provide a client-side search box for AgGrid."""
     return dbc.Row([
         dbc.Col([
-            dcc.Dropdown(
-                id='position-filter',
-                options=[{'label': pos, 'value': pos} for pos in positions] + [{'label': 'All', 'value': 'All'}],
-                value='All',
-                placeholder="Select Position"
+            dcc.Input(
+                id='search-input',
+                type='text',
+                placeholder='Search players...',
+                className='form-control',
             )
         ], width=3),
-        dbc.Col([
-            dcc.Input(id='search-input', type='text', placeholder='Search players...', className="form-control")
-        ], width=3)
-    ], className="mb-4")
+    ], className='mb-4')
+
 
 def create_scoring_controls():
     return dbc.Row([
@@ -58,20 +58,21 @@ def create_scoring_controls():
         ], width=2),
     ], className="mb-4")
 
+
 def create_draft_input(players, teams):
     return dbc.Row([
         dbc.Col([
             dcc.Dropdown(
                 id='draft-name',
                 options=[{'label': player, 'value': player} for player in players],
-                placeholder="Select Player"
+                placeholder="Select Player",
             )
         ], width=3),
         dbc.Col([
             dcc.Dropdown(
                 id='draft-team',
                 options=[{'label': f'Team {i}', 'value': f'Team {i}'} for i in range(1, teams + 1)],
-                placeholder="Select Team"
+                placeholder="Select Team",
             )
         ], width=3),
         dbc.Col([
@@ -79,9 +80,10 @@ def create_draft_input(players, teams):
         ], width=2),
         dbc.Col([
             dbc.Button('Draft Player', id='draft-button', color="primary", className="mr-2"),
-            dbc.Button('Undo Last Pick', id='undo-button', color="secondary")
-        ], width=4)
+            dbc.Button('Undo Last Pick', id='undo-button', color="secondary"),
+        ], width=4),
     ], className="mb-4")
+
 
 def create_player_table():
     return AgGrid(
@@ -93,20 +95,22 @@ def create_player_table():
             {"headerName": "Auction Value", "field": "AuctionValue", "filter": True, "sortable": True},
             {"headerName": "Drafted", "field": "Drafted", "filter": True, "sortable": True},
             {"headerName": "Drafted By", "field": "DraftedBy", "filter": True, "sortable": True},
-            {"headerName": "Price Paid", "field": "PricePaid", "filter": True, "sortable": True}
+            {"headerName": "Price Paid", "field": "PricePaid", "filter": True, "sortable": True},
         ],
         rowData=[],
         defaultColDef={"resizable": True, "filter": True, "sortable": True},
         dashGridOptions={"pagination": True, "paginationAutoPageSize": True},
         className="ag-theme-alpine",
-        style={"height": 1600}
+        style={"height": 1600},
     )
+
 
 def create_draft_summary():
     return html.Div([
         html.H3("Overall Draft Summary"),
-        html.Div(id='draft-summary')
+        html.Div(id='draft-summary'),
     ])
+
 
 def create_team_summaries(teams):
     return html.Div([
@@ -117,23 +121,27 @@ def create_team_summaries(teams):
                 dbc.CardBody([
                     html.Div(id=f'team-{i}-summary'),
                     html.Div(id=f'team-{i}-remaining-budget', className="mt-2 font-weight-bold"),
-                    dcc.Graph(id=f'team-{i}-composition-chart')
-                ])
-            ], className="mb-3", style={'width':'100%'}) for i in range(1, teams + 1)
-        ])
+                    dcc.Graph(id=f'team-{i}-composition-chart'),
+                ]),
+            ], className="mb-3", style={'width': '100%'}),
+            for i in range(1, teams + 1)
+        ]),
     ])
+
 
 def create_graphs():
     return html.Div([
         dcc.Graph(id='value-distribution-graph'),
-        dcc.Graph(id='top-players-graph')
+        dcc.Graph(id='top-players-graph'),
     ])
 
-def create_layout(players, positions, teams):
+
+def create_layout(players, teams, data):
     return dbc.Container([
+        dcc.Store(id='player-data', data=data),
         html.H1("Fantasy Football Draft Dashboard", className="my-4"),
         create_scoring_controls(),
-        create_filters(positions),
+        create_filters(),
         create_draft_input(players, teams),
         dbc.Row([
             dbc.Col(create_player_table(), width=12),
@@ -145,5 +153,5 @@ def create_layout(players, positions, teams):
             dbc.Col([create_draft_summary()], width=12)
         ]),
         html.Div(id='draft-message', className="mt-3"),
-        create_graphs()
+        create_graphs(),
     ], fluid=True)


### PR DESCRIPTION
## Summary
- Cache computed player data in a new `dcc.Store` and recalc only when scoring settings change
- Split draft handling, table updates, and summaries into smaller callbacks driven by stored data
- Rely on AgGrid's client-side filtering with a quick search input to avoid server-side filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2668a65388322a28566caa1474c3b