### PR TITLE
Allow duplicate outputs for shared Dash components

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,7 +154,7 @@ app.layout = create_layout(
 )
 
 @app.callback(
-    Output('player-data', 'data'),
+    Output('player-data', 'data', allow_duplicate=True),
     [
         Input('pass-yds-pt', 'value'),
         Input('pass-td-pts', 'value'),
@@ -167,6 +167,7 @@ app.layout = create_layout(
         Input('rec-td-pts', 'value'),
     ],
     State('player-data', 'data'),
+    prevent_initial_call=True,
 )
 def update_player_data(pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_pts,
                        fum_pen, rec_yds_pt, rec_per, rec_td_pts, current_data):
@@ -212,7 +213,7 @@ def update_player_data(pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_p
 
 
 @app.callback(
-    Output('player-data', 'data'),
+    Output('player-data', 'data', allow_duplicate=True),
     [Input('draft-button', 'n_clicks'),
      Input('undo-button', 'n_clicks')],
     [State('draft-name', 'value'),

--- a/pages/draftboard.py
+++ b/pages/draftboard.py
@@ -59,7 +59,7 @@ def layout():
 
 # Enable the save button only when changes are made
 @callback(
-    Output('save-draftboard', 'disabled'),
+    Output('save-draftboard', 'disabled', allow_duplicate=True),
     Input('draftboard-table', 'data_timestamp'),
     State('draftboard-table', 'data'),
     State('draftboard-saved', 'data'),
@@ -76,7 +76,7 @@ def toggle_save_button(timestamp, current_rows, saved_rows):
 @callback(
     Output('draftboard-status', 'children'),
     Output('draftboard-saved', 'data'),
-    Output('save-draftboard', 'disabled'),
+    Output('save-draftboard', 'disabled', allow_duplicate=True),
     Output('last-save-timestamp', 'data'),
     Input('save-draftboard', 'n_clicks'),
     State('draftboard-table', 'data'),


### PR DESCRIPTION
## Summary
- enable duplicate outputs in draftboard callbacks to fix Dash runtime error
- allow player-data store to be updated from multiple callbacks

## Testing
- `python -m py_compile app.py pages/draftboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a26b528ad8832286ae8eec289b82b2