### PR TITLE
Add playground page and navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,154 +3,46 @@ from dash import dcc, html, Output, Input, State
 from plotly import express as px
 import dash_bootstrap_components as dbc
 import pandas as pd
-from utility import helpers, scoring
 import plotly.graph_objs as go
-from layout import create_layout
-import warnings
-warnings.filterwarnings('ignore', category=pd.errors.SettingWithCopyWarning)
-
-def load_position_data(pos: str) -> pd.DataFrame:
-    data = helpers.get_position_data(pos)
-    data = helpers.clean_offense_data(data, pos=pos)
-    scoring_map = {
-        'QB': scoring.calculate_qb_points,
-        'RB': scoring.calculate_rb_wr_points,
-        'WR': scoring.calculate_rb_wr_points,
-        'TE': scoring.calculate_te_points,
-    }
-    score_func = scoring_map.get(pos)
-    if score_func:
-        data['ModelPoints'] = data.apply(score_func, axis=1)
-    else:
-        data['ModelPoints'] = 0.0
-    return data
-
-
-positions = ['QB', 'RB', 'WR', 'TE']
-position_data = {pos: load_position_data(pos) for pos in positions}
-
-merge_all = pd.concat(position_data.values(), ignore_index=True)
-merge_all.to_csv('data/all_data.csv', index=False)
-grouped_data = merge_all.groupby('Name').agg({'ModelPoints': ['sum', 'count']})
-grouped_data.to_csv('data/grouped_data.csv', index=True)
-
-def calculate_vorp_and_rank(group):
-    position = group['Position'].iloc[0]
-    if position == 'QB':
-        baseline = group['ModelPoints'].nlargest(14).iloc[-1]
-    elif position in ['RB', 'WR']:
-        baseline = group['ModelPoints'].nlargest(48).iloc[-1]
-    elif position == 'TE':
-        baseline = group['ModelPoints'].nlargest(14).iloc[-1]
-    else:
-        baseline = 0  # For any other positions
-    
-    group['VORP'] = group['ModelPoints'] - baseline
-    
-    # Add ranking
-    group['Rank'] = group['ModelPoints'].rank(method='min', ascending=False)
-    
-    return group
-
-# Apply the function to each group
-grouped_vorp_and_rank_data = merge_all.groupby(['Week', 'Position']).apply(calculate_vorp_and_rank).reset_index(drop=True)
-
-grouped_vorp_and_rank_data = grouped_vorp_and_rank_data.sort_values(['Week', 'Position', 'Rank'])
-
-### At this point we have correctly built data
-# using "df" from now on:
-
-df = grouped_vorp_and_rank_data.copy(deep=True)
-
-# Step 1: Aggregate weekly data into season totals
-season_totals = df.groupby(['Name', 'Position', 'Team']).agg({
-    'PassYds': 'sum',
-    'PassTD': 'sum',
-    'Int': 'sum',
-    'RushYds': 'sum',
-    'RushTD': 'sum',
-    'Rec': 'sum',
-    'RecYds': 'sum',
-    'RecTD': 'sum',
-    'Fum': 'sum',
-    'ModelPoints': 'sum',
-}).reset_index()
-
-# Step 2: Split the dataframe by position
-positions = ['QB', 'RB', 'WR', 'TE']
-base_data = {pos: helpers.clean_offense_data(helpers.get_position_data(pos), pos=pos) for pos in positions}
-
-NUM_TEAMS = 12
-INITIAL_BUDGET = 200
-TOTAL_BUDGET = NUM_TEAMS * INITIAL_BUDGET
-MIN_SPEND = NUM_TEAMS * 17
-AUCTION_BUDGET = TOTAL_BUDGET - MIN_SPEND
-
-def compute_values(config):
-    qb = base_data['QB'].copy()
-    qb['ModelPoints'] = qb.apply(lambda r: scoring.calculate_qb_points(r, config['QB']), axis=1)
-    rb = base_data['RB'].copy()
-    rb['ModelPoints'] = rb.apply(lambda r: scoring.calculate_rb_wr_points(r, config['RB_WR']), axis=1)
-    wr = base_data['WR'].copy()
-    wr['ModelPoints'] = wr.apply(lambda r: scoring.calculate_rb_wr_points(r, config['RB_WR']), axis=1)
-    te = base_data['TE'].copy()
-    te['ModelPoints'] = te.apply(lambda r: scoring.calculate_te_points(r, config['TE']), axis=1)
-
-    merge_all = pd.concat([qb, rb, wr, te], ignore_index=True)
-    season_totals = merge_all.groupby(['Name', 'Position', 'Team']).agg({
-        'PassYds': 'sum',
-        'PassTD': 'sum',
-        'Int': 'sum',
-        'RushYds': 'sum',
-        'RushTD': 'sum',
-        'Rec': 'sum',
-        'RecYds': 'sum',
-        'RecTD': 'sum',
-        'Fum': 'sum',
-        'ModelPoints': 'sum',
-    }).reset_index()
-
-    position_dfs = {pos: season_totals[season_totals['Position'] == pos].sort_values('ModelPoints', ascending=False) for pos in positions}
-    baselines = {'QB': 14, 'RB': 48, 'WR': 48, 'TE': 14}
-    for pos in positions:
-        df_pos = position_dfs[pos]
-        if len(df_pos) >= baselines[pos]:
-            baseline_value = df_pos.iloc[baselines[pos]-1]['ModelPoints']
-        else:
-            baseline_value = df_pos['ModelPoints'].min()
-        df_pos['VORP'] = df_pos['ModelPoints'] - baseline_value
-        position_dfs[pos] = df_pos
-
-    total_vorp = sum(df['VORP'].clip(lower=0).sum() for df in position_dfs.values())
-    price_per_point = AUCTION_BUDGET / total_vorp if total_vorp else 0
-
-    for pos in positions:
-        position_dfs[pos]['AuctionValue'] = (position_dfs[pos]['VORP'].clip(lower=0) * price_per_point).round(2)
-
-    all_players = pd.concat(position_dfs.values())
-    all_players_sorted = all_players.sort_values('AuctionValue', ascending=False)
-    return all_players_sorted
-
-DEFAULT_CONFIG = {
-    'QB': scoring.QB_SCORING_DEFAULT,
-    'RB_WR': scoring.RB_WR_SCORING_DEFAULT,
-    'TE': scoring.TE_SCORING_DEFAULT,
-}
-
-all_players_sorted = compute_values(DEFAULT_CONFIG)
-all_players_sorted['Drafted'] = False
-all_players_sorted['DraftedBy'] = ''
-all_players_sorted['PricePaid'] = 0
+from utility import scoring
+from models.auction import (
+    all_players_sorted,
+    NUM_TEAMS,
+    compute_values,
+    INITIAL_BUDGET,
+)
 
 draft_history = []
 
-app = dash.Dash(__name__, use_pages=True, title='FF', update_title='****', suppress_callback_exceptions=True, external_stylesheets=[dbc.themes.BOOTSTRAP])
+app = dash.Dash(
+    __name__,
+    use_pages=True,
+    title='FF',
+    update_title='****',
+    suppress_callback_exceptions=True,
+    external_stylesheets=[dbc.themes.BOOTSTRAP],
+)
 server = app.server
 
-app.layout = create_layout(
-    all_players_sorted['Name'].tolist(),
-    NUM_TEAMS,
-    all_players_sorted.to_dict('records'),
+app.layout = dbc.Container(
+    [
+        dbc.NavbarSimple(
+            children=[
+                dbc.NavItem(dbc.NavLink("Home", href="/")),
+                dbc.NavItem(dbc.NavLink("Auction", href="/auction")),
+                dbc.NavItem(dbc.NavLink("Draft Board", href="/draftboard")),
+                dbc.NavItem(dbc.NavLink("Offense Data", href="/offensedata")),
+                dbc.NavItem(dbc.NavLink("History", href="/history")),
+                dbc.NavItem(dbc.NavLink("Playground", href="/playground")),
+            ],
+            brand="sigFantasy",
+            brand_href="/",
+            color="grey",
+            fluid=True,
+        ),
+        dash.page_container,
+    ],
+    fluid=True,
 )
 
 @app.callback(
@@ -242,6 +134,7 @@ def update_draft(draft_clicks, undo_clicks, draft_name, draft_team, draft_price,
 @app.callback(Output('player-table', 'rowData'), Input('player-data', 'data'))
 def update_table(data):
     return data or []
+
 
 @app.callback(
     [Output('value-distribution-graph', 'figure'),

--- a/models/auction.py
+++ b/models/auction.py
@@ -1,0 +1,161 @@
+import pandas as pd
+import warnings
+from utility import helpers, scoring
+
+warnings.filterwarnings('ignore', category=pd.errors.SettingWithCopyWarning)
+
+
+def load_position_data(pos: str) -> pd.DataFrame:
+    data = helpers.get_position_data(pos)
+    data = helpers.clean_offense_data(data, pos=pos)
+    scoring_map = {
+        'QB': scoring.calculate_qb_points,
+        'RB': scoring.calculate_rb_wr_points,
+        'WR': scoring.calculate_rb_wr_points,
+        'TE': scoring.calculate_te_points,
+    }
+    score_func = scoring_map.get(pos)
+    if score_func:
+        data['ModelPoints'] = data.apply(score_func, axis=1)
+    else:
+        data['ModelPoints'] = 0.0
+    return data
+
+
+positions = ['QB', 'RB', 'WR', 'TE']
+
+position_data = {pos: load_position_data(pos) for pos in positions}
+merge_all = pd.concat(position_data.values(), ignore_index=True)
+merge_all.to_csv('data/all_data.csv', index=False)
+
+grouped_data = merge_all.groupby('Name').agg({'ModelPoints': ['sum', 'count']})
+grouped_data.to_csv('data/grouped_data.csv', index=True)
+
+
+def calculate_vorp_and_rank(group: pd.DataFrame) -> pd.DataFrame:
+    position = group['Position'].iloc[0]
+    if position == 'QB':
+        baseline = group['ModelPoints'].nlargest(14).iloc[-1]
+    elif position in ['RB', 'WR']:
+        baseline = group['ModelPoints'].nlargest(48).iloc[-1]
+    elif position == 'TE':
+        baseline = group['ModelPoints'].nlargest(14).iloc[-1]
+    else:
+        baseline = 0
+
+    group['VORP'] = group['ModelPoints'] - baseline
+    group['Rank'] = group['ModelPoints'].rank(method='min', ascending=False)
+    return group
+
+
+grouped_vorp_and_rank_data = (
+    merge_all.groupby(['Week', 'Position'])
+    .apply(calculate_vorp_and_rank)
+    .reset_index(drop=True)
+)
+
+grouped_vorp_and_rank_data = grouped_vorp_and_rank_data.sort_values(
+    ['Week', 'Position', 'Rank']
+)
+
+
+df = grouped_vorp_and_rank_data.copy(deep=True)
+
+season_totals = df.groupby(['Name', 'Position', 'Team']).agg({
+    'PassYds': 'sum',
+    'PassTD': 'sum',
+    'Int': 'sum',
+    'RushYds': 'sum',
+    'RushTD': 'sum',
+    'Rec': 'sum',
+    'RecYds': 'sum',
+    'RecTD': 'sum',
+    'Fum': 'sum',
+    'ModelPoints': 'sum',
+}).reset_index()
+
+base_data = {
+    pos: helpers.clean_offense_data(helpers.get_position_data(pos), pos=pos)
+    for pos in positions
+}
+
+NUM_TEAMS = 12
+INITIAL_BUDGET = 200
+TOTAL_BUDGET = NUM_TEAMS * INITIAL_BUDGET
+MIN_SPEND = NUM_TEAMS * 17
+AUCTION_BUDGET = TOTAL_BUDGET - MIN_SPEND
+
+
+def compute_values(config):
+    qb = base_data['QB'].copy()
+    qb['ModelPoints'] = qb.apply(
+        lambda r: scoring.calculate_qb_points(r, config['QB']), axis=1
+    )
+    rb = base_data['RB'].copy()
+    rb['ModelPoints'] = rb.apply(
+        lambda r: scoring.calculate_rb_wr_points(r, config['RB_WR']), axis=1
+    )
+    wr = base_data['WR'].copy()
+    wr['ModelPoints'] = wr.apply(
+        lambda r: scoring.calculate_rb_wr_points(r, config['RB_WR']), axis=1
+    )
+    te = base_data['TE'].copy()
+    te['ModelPoints'] = te.apply(
+        lambda r: scoring.calculate_te_points(r, config['TE']), axis=1
+    )
+
+    merge_all = pd.concat([qb, rb, wr, te], ignore_index=True)
+    season_totals = merge_all.groupby(['Name', 'Position', 'Team']).agg({
+        'PassYds': 'sum',
+        'PassTD': 'sum',
+        'Int': 'sum',
+        'RushYds': 'sum',
+        'RushTD': 'sum',
+        'Rec': 'sum',
+        'RecYds': 'sum',
+        'RecTD': 'sum',
+        'Fum': 'sum',
+        'ModelPoints': 'sum',
+    }).reset_index()
+
+    position_dfs = {
+        pos: season_totals[season_totals['Position'] == pos].sort_values(
+            'ModelPoints', ascending=False
+        )
+        for pos in positions
+    }
+    baselines = {'QB': 14, 'RB': 48, 'WR': 48, 'TE': 14}
+    for pos in positions:
+        df_pos = position_dfs[pos]
+        if len(df_pos) >= baselines[pos]:
+            baseline_value = df_pos.iloc[baselines[pos] - 1]['ModelPoints']
+        else:
+            baseline_value = df_pos['ModelPoints'].min()
+        df_pos['VORP'] = df_pos['ModelPoints'] - baseline_value
+        position_dfs[pos] = df_pos
+
+    total_vorp = sum(df['VORP'].clip(lower=0).sum() for df in position_dfs.values())
+    price_per_point = AUCTION_BUDGET / total_vorp if total_vorp else 0
+
+    for pos in positions:
+        position_dfs[pos]['AuctionValue'] = (
+            position_dfs[pos]['VORP'].clip(lower=0) * price_per_point
+        ).round(2)
+
+    all_players = pd.concat(position_dfs.values())
+    all_players_sorted = all_players.sort_values('AuctionValue', ascending=False)
+    return all_players_sorted
+
+
+DEFAULT_CONFIG = {
+    'QB': scoring.QB_SCORING_DEFAULT,
+    'RB_WR': scoring.RB_WR_SCORING_DEFAULT,
+    'TE': scoring.TE_SCORING_DEFAULT,
+}
+
+
+all_players_sorted = compute_values(DEFAULT_CONFIG)
+all_players_sorted['Drafted'] = False
+all_players_sorted['DraftedBy'] = ''
+all_players_sorted['PricePaid'] = 0
+

--- a/pages/auction.py
+++ b/pages/auction.py
@@ -1,0 +1,12 @@
+import dash
+from layout import create_layout
+from models.auction import all_players_sorted, NUM_TEAMS
+
+
+dash.register_page(__name__, path='/auction')
+
+layout = create_layout(
+    all_players_sorted['Name'].tolist(),
+    NUM_TEAMS,
+    all_players_sorted.to_dict('records'),
+)

--- a/pages/playground.py
+++ b/pages/playground.py
@@ -1,0 +1,43 @@
+import dash
+from dash import html, dcc, Input, Output, callback
+import dash_bootstrap_components as dbc
+import dash_table
+import plotly.express as px
+from utility import helpers
+
+
+dash.register_page(__name__, path='/playground')
+
+# Load data used in this playground
+sched_data = helpers.clean_schedule(helpers.get_schedule())
+qb_data = helpers.clean_offense_data(helpers.get_position_data('QB'), pos='QB')
+
+
+def layout():
+    return dbc.Container(
+        [
+            html.H1("Playground"),
+            html.H2("2025 Schedule"),
+            dash_table.DataTable(
+                id='schedule-table',
+                columns=[{'name': c, 'id': c} for c in sched_data.columns],
+                data=sched_data.to_dict('records'),
+                page_size=20,
+            ),
+            html.H2("QB Passing Yards Distribution"),
+            dcc.Dropdown(
+                id='qb-playground-dropdown',
+                options=[{'label': n, 'value': n} for n in qb_data['Name'].unique()],
+                value=qb_data['Name'].iloc[0],
+            ),
+            dcc.Graph(id='qb-passing-hist'),
+        ],
+        fluid=True,
+    )
+
+
+@callback(Output('qb-passing-hist', 'figure'), Input('qb-playground-dropdown', 'value'))
+def update_qb_hist(name):
+    filtered = qb_data[qb_data['Name'] == name]
+    fig = px.histogram(filtered, x='PassYds', nbins=20, title=f'Passing Yards for {name}')
+    return fig


### PR DESCRIPTION
## Summary
- Introduce shared auction data module and convert draft dashboard into a dedicated page
- Add navigation bar with links across home, auction, data, history, draft board, and new playground page
- Create a playground page with schedule table and QB passing yard exploration

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26c5451608322a0dbe7e826b2ba55