### PR TITLE
Add season-long projections page

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ app.layout = dbc.Container(
                 dbc.NavItem(dbc.NavLink("Auction", href="/auction")),
                 dbc.NavItem(dbc.NavLink("Draft Board", href="/draftboard")),
                 dbc.NavItem(dbc.NavLink("Offense Data", href="/offensedata")),
+                dbc.NavItem(dbc.NavLink("Projections", href="/projections")),
                 dbc.NavItem(dbc.NavLink("History", href="/history")),
                 dbc.NavItem(dbc.NavLink("Playground", href="/playground")),
             ],

--- a/pages/projections.py
+++ b/pages/projections.py
@@ -1,0 +1,58 @@
+import dash
+from dash import html, dcc, Input, Output, callback
+from dash_ag_grid import AgGrid
+import dash_bootstrap_components as dbc
+from utility.helpers import get_season_long_projections
+
+# Register the projections page
+
+dash.register_page(__name__, path='/projections')
+
+# Load projection data
+proj_df = get_season_long_projections()
+
+
+def layout():
+    """Layout for the season-long projections page."""
+    positions = sorted(proj_df['Pos'].dropna().unique())
+    return dbc.Container(
+        [
+            html.H1("Season-long Projections"),
+            dcc.Dropdown(
+                id='proj-position-filter',
+                options=[{"label": pos, "value": pos} for pos in positions],
+                multi=True,
+                placeholder="Filter by position",
+            ),
+            AgGrid(
+                id='proj-grid',
+                columnDefs=[
+                    {"headerName": "Name", "field": "Name", "sortable": True, "filter": True},
+                    {"headerName": "Position", "field": "Pos", "sortable": True, "filter": True},
+                    {
+                        "headerName": "Projections",
+                        "field": "Projections",
+                        "sortable": True,
+                        "filter": True,
+                        "sort": "desc",
+                    },
+                ],
+                rowData=proj_df.to_dict('records'),
+                defaultColDef={"resizable": True, "filter": True, "sortable": True},
+                dashGridOptions={"pagination": True, "paginationAutoPageSize": True, "rowBuffer": 0},
+                className="ag-theme-alpine",
+                style={"height": "70vh"},
+            ),
+        ],
+        fluid=True,
+    )
+
+
+@callback(Output('proj-grid', 'rowData'), Input('proj-position-filter', 'value'))
+def update_grid(selected_positions):
+    """Filter grid data based on selected positions."""
+    if selected_positions:
+        filtered = proj_df[proj_df['Pos'].isin(selected_positions)]
+    else:
+        filtered = proj_df
+    return filtered.to_dict('records')


### PR DESCRIPTION
## Summary
- add projections page showing season-long data in an AgGrid with position filter
- register projections page in navbar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a522d5e35c832293084377b423da09