### PR TITLE
feat: add sportsbook props helper and prop scoring

### DIFF
--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -84,3 +84,55 @@ def test_calculate_rb_wr_points_zero_line():
     })
 
     assert scoring.calculate_rb_wr_points(row) == 0
+
+
+def test_calculate_prop_points_dispatch():
+    scoring, _, _ = _load_scoring()
+
+    df = pd.DataFrame(
+        [
+            {
+                'Pos': 'QB',
+                'PassYds': 100,
+                'PassTD': 1,
+                'Int': 0,
+                'RushYds': 0,
+                'RushTD': 0,
+                'Fum': 0,
+            },
+            {
+                'Pos': 'RB',
+                'RushYds': 10,
+                'RushTD': 0,
+                'Fum': 0,
+                'RecYds': 10,
+                'RecTD': 0,
+                'Rec': 1,
+            },
+            {
+                'Pos': 'TE',
+                'RecYds': 10,
+                'RecTD': 0,
+                'Rec': 1,
+                'Fum': 0,
+            },
+        ]
+    )
+
+    config = {
+        'QB': scoring.QB_SCORING_DEFAULT,
+        'RB': scoring.RB_WR_SCORING_DEFAULT,
+        'WR': scoring.RB_WR_SCORING_DEFAULT,
+        'TE': scoring.TE_SCORING_DEFAULT,
+    }
+
+    with patch.object(scoring, 'calculate_qb_points', return_value=1) as qb_mock, \
+        patch.object(scoring, 'calculate_rb_wr_points', return_value=2) as rb_mock, \
+        patch.object(scoring, 'calculate_te_points', return_value=3) as te_mock:
+
+        result = scoring.calculate_prop_points(df, config)
+
+        assert list(result['ModelPoints']) == [1, 2, 3]
+        qb_mock.assert_called_once()
+        rb_mock.assert_called()
+        te_mock.assert_called_once()

--- a/utility/helpers.py
+++ b/utility/helpers.py
@@ -62,6 +62,47 @@ def get_season_long_projections():
     return df
 
 
+def get_sportsbook_props():
+    """Return sportsbook prop projections with standardized columns.
+
+    The data is sourced from ``assets/season_long_proj_table.csv`` and the
+    columns are renamed to align with the scoring keys used throughout the
+    project.  Any non-numeric values in the statistical columns are coerced to
+    zero so downstream scoring functions can operate without additional type
+    checks.
+    """
+
+    file_path = (
+        Path(__file__).resolve().parents[1]
+        / "assets"
+        / "season_long_proj_table.csv"
+    )
+
+    try:
+        df = pd.read_csv(file_path)
+    except Exception:
+        return pd.DataFrame()
+
+    rename_map = {
+        "Pass Yards": "PassYds",
+        "Pass TDs": "PassTD",
+        "Ints": "Int",
+        "Rush Yards": "RushYds",
+        "Rush TDs": "RushTD",
+        "Rec Yards": "RecYds",
+        "Rec TDs": "RecTD",
+        "Receptions": "Rec",
+        "Fumbles": "Fum",
+    }
+    df.rename(columns=rename_map, inplace=True)
+
+    for col in rename_map.values():
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0)
+
+    return df
+
+
 def get_defense_metrics():
     """Return per-team defensive metrics.
 


### PR DESCRIPTION
## Summary
- load sportsbook projection CSV with standardized stat columns
- add dispatcher to compute model points per position
- cover dispatcher with unit test

## Testing
- `pytest -q` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a522c8a0d083229fb123a16bcb5712