### PR TITLE
Integrate prop history features into modeling pipeline

### DIFF
--- a/modeling/predict.py
+++ b/modeling/predict.py
@@ -2,7 +2,7 @@ import os
 import json
 import numpy as np
 import pandas as pd
-from features import build_features
+from features import build_features, load_prop_history
 
 
 def load_model(position: str, models_dir: str = "models"):
@@ -18,6 +18,11 @@ def predict_position(df: pd.DataFrame, position: str, models_dir: str = "models"
     """Generate fantasy point projections for ``df`` using a trained model."""
     model_data = load_model(position, models_dir)
     columns = model_data["columns"]
+
+    props = load_prop_history()
+    if not props.empty:
+        df = df.merge(props.drop(columns=["Pos"]), on="Name", how="left")
+
     feats = build_features(df)
     X = feats.select_dtypes(include=[float, int])
     X = X.reindex(columns=columns, fill_value=0)

--- a/modeling/train.py
+++ b/modeling/train.py
@@ -3,7 +3,7 @@ import json
 from typing import List
 import numpy as np
 import pandas as pd
-from features import load_player_stats, build_features
+from features import load_player_stats, build_features, load_prop_history
 
 
 def train_position_model(position: str, data_dir: str = "data", models_dir: str = "models") -> str:
@@ -21,6 +21,12 @@ def train_position_model(position: str, data_dir: str = "data", models_dir: str 
     df = load_player_stats(data_dir, position)
     if df.empty:
         raise ValueError(f"No data found for position {position}")
+
+    props = load_prop_history()
+    if not props.empty:
+        props_pos = props[props["Pos"].str.upper() == position.upper()]
+        df = df.merge(props_pos.drop(columns=["Pos"]), on="Name", how="left")
+
     df = build_features(df)
     if "Points" not in df.columns:
         raise ValueError("Required target column 'Points' not present")

--- a/models/qb.json
+++ b/models/qb.json
@@ -1,1 +1,1 @@
-{"coef": [0.0], "columns": []}
+{"coef": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "columns": ["line_attempts", "line_comps", "line_pass_tds", "line_pass_yards", "line_ints", "line_receptions", "line_rec_yards", "line_rec_tds", "line_rush_yards", "line_rush_tds", "line_fumbles", "implied_total", "market_differential"]}

--- a/models/rb.json
+++ b/models/rb.json
@@ -1,1 +1,1 @@
-{"coef": [0.0], "columns": []}
+{"coef": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "columns": ["line_attempts", "line_comps", "line_pass_tds", "line_pass_yards", "line_ints", "line_receptions", "line_rec_yards", "line_rec_tds", "line_rush_yards", "line_rush_tds", "line_fumbles", "implied_total", "market_differential"]}

--- a/models/te.json
+++ b/models/te.json
@@ -1,1 +1,1 @@
-{"coef": [0.0], "columns": []}
+{"coef": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "columns": ["line_attempts", "line_comps", "line_pass_tds", "line_pass_yards", "line_ints", "line_receptions", "line_rec_yards", "line_rec_tds", "line_rush_yards", "line_rush_tds", "line_fumbles", "implied_total", "market_differential"]}

--- a/models/wr.json
+++ b/models/wr.json
@@ -1,1 +1,1 @@
-{"coef": [0.0], "columns": []}
+{"coef": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "columns": ["line_attempts", "line_comps", "line_pass_tds", "line_pass_yards", "line_ints", "line_receptions", "line_rec_yards", "line_rec_tds", "line_rush_yards", "line_rush_tds", "line_fumbles", "implied_total", "market_differential"]}


### PR DESCRIPTION
## Summary
- load historical prop tables and compute line, implied total, and market differential features
- merge prop-based features in model training and prediction
- update serialized models to include prop feature columns

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python modeling/train.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a522f2ef408322be6725f467b726af