### PR TITLE
Fix RB/WR scoring call in auction model

### DIFF
--- a/models/auction.py
+++ b/models/auction.py
@@ -92,13 +92,9 @@ def compute_values(config):
         lambda r: scoring.calculate_qb_points(r, config['QB']), axis=1
     )
     rb = base_data['RB'].copy()
-    rb['ModelPoints'] = rb.apply(
-        lambda r: scoring.calculate_rb_wr_points(r, config['RB_WR']), axis=1
-    )
+    rb['ModelPoints'] = rb.apply(scoring.calculate_rb_wr_points, axis=1)
     wr = base_data['WR'].copy()
-    wr['ModelPoints'] = wr.apply(
-        lambda r: scoring.calculate_rb_wr_points(r, config['RB_WR']), axis=1
-    )
+    wr['ModelPoints'] = wr.apply(scoring.calculate_rb_wr_points, axis=1)
     te = base_data['TE'].copy()
     te['ModelPoints'] = te.apply(
         lambda r: scoring.calculate_te_points(r, config['TE']), axis=1


### PR DESCRIPTION
## Summary
- Fix auction model TypeError by removing extra scoring config for RB/WR

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a5292356dc83229ceca590d46905a4