### PR TITLE
Replace draftboard DataTable with AgGrid

### DIFF
--- a/assets/draftboard.css
+++ b/assets/draftboard.css
@@ -1,0 +1,4 @@
+.drafted {
+    background-color: lightgrey !important;
+    color: grey;
+}


### PR DESCRIPTION
## Summary
- swap `dash_table.DataTable` for `dash_ag_grid.AgGrid` with editable owner/price columns
- add global search and name/position/team dropdown filters
- rework save callbacks to persist edits from AgGrid and gray drafted rows

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_68a52b3778e4832293d4a62862cba4c7