### PR TITLE
Add league settings page with persistent scoring config

### DIFF
--- a/assets/settings.json
+++ b/assets/settings.json
@@ -1,0 +1,38 @@
+{
+  "QB": {
+    "PassYds": {"points_per": 25, "bonuses": {"250": 3, "350": 3, "450": 3, "550": 3, "650": 3}},
+    "PassTD": {"points": 6},
+    "Int": {"points": -3},
+    "RushYds": {"points_per": 10, "bonuses": {"100": 3, "200": 3, "300": 3}},
+    "RushTD": {"points": 6},
+    "Fum": {"points": -3}
+  },
+  "RB": {
+    "RushYds": {"points_per": 10, "bonuses": {"100": 3, "200": 3, "300": 3}},
+    "RushTD": {"points": 6},
+    "Fum": {"points": -3},
+    "RecYds": {"points_per": 10, "bonuses": {"100": 3, "200": 3, "300": 3}},
+    "Rec": {"points_per": 5, "bonuses": {"10": 1, "15": 1}},
+    "RecTD": {"points": 6},
+    "BigRushTD": {"80": 3, "60": 2, "40": 1},
+    "BigRec": {"20": 1, "40": 2},
+    "BigRecTD": {"80": 3, "60": 2, "40": 1}
+  },
+  "WR": {
+    "RushYds": {"points_per": 10, "bonuses": {"100": 3, "200": 3, "300": 3}},
+    "RushTD": {"points": 6},
+    "Fum": {"points": -3},
+    "RecYds": {"points_per": 10, "bonuses": {"100": 3, "200": 3, "300": 3}},
+    "Rec": {"points_per": 5, "bonuses": {"10": 1, "15": 1}},
+    "RecTD": {"points": 6},
+    "BigRushTD": {"80": 3, "60": 2, "40": 1},
+    "BigRec": {"20": 1, "40": 2},
+    "BigRecTD": {"80": 3, "60": 2, "40": 1}
+  },
+  "TE": {
+    "RecYds": {"points_per": 10, "bonuses": {"100": 3, "200": 3, "300": 3}},
+    "Rec": {"points_per": 5, "bonuses": {"10": 1, "15": 1}},
+    "RecTD": {"points": 6},
+    "Fum": {"points": -3}
+  }
+}

--- a/layout.py
+++ b/layout.py
@@ -163,7 +163,6 @@ def create_layout(players, teams, data):
     return dbc.Container([
         dcc.Store(id='player-data', data=data),
         html.H1("Fantasy Football Draft Dashboard", className="my-4"),
-        create_scoring_controls(),
         create_filters(),
         create_draft_input(players, teams),
         dbc.Row([

--- a/pages/league_settings.py
+++ b/pages/league_settings.py
@@ -1,0 +1,112 @@
+import dash
+from dash import html, dcc, Input, Output, State, callback
+import dash_bootstrap_components as dbc
+from copy import deepcopy
+from pathlib import Path
+
+from layout import create_scoring_controls
+from utility.scoring import (
+    SCORING_CONFIG_DEFAULT,
+    save_config,
+    load_config,
+)
+
+# Register page
+
+dash.register_page(__name__, path="/settings")
+
+SETTINGS_PATH = Path("assets/settings.json")
+
+
+def layout():
+    return dbc.Container(
+        [
+            html.H1("League Settings"),
+            create_scoring_controls(),
+            dbc.Button("Save", id="save-config", color="primary", className="me-2"),
+            dbc.Button("Load", id="load-config", color="secondary"),
+        ],
+        fluid=True,
+    )
+
+
+@callback(
+    Output("scoring-config", "data"),
+    Input("save-config", "n_clicks"),
+    State("pass-yds-pt", "value"),
+    State("pass-td-pts", "value"),
+    State("int-pen", "value"),
+    State("rush-yds-pt", "value"),
+    State("rush-td-pts", "value"),
+    State("fum-pen", "value"),
+    State("rec-yds-pt", "value"),
+    State("rec-per", "value"),
+    State("rec-td-pts", "value"),
+    prevent_initial_call=True,
+)
+def save_settings(n_clicks, pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_pts,
+                  fum_pen, rec_yds_pt, rec_per, rec_td_pts):
+    """Persist scoring settings and update the store."""
+
+    config = deepcopy(SCORING_CONFIG_DEFAULT)
+    config["QB"]["PassYds"]["points_per"] = pass_yds_pt
+    config["QB"]["PassTD"]["points"] = pass_td_pts
+    config["QB"]["Int"]["points"] = int_pen
+    for pos in ("QB", "RB", "WR"):
+        if "RushYds" in config.get(pos, {}):
+            config[pos]["RushYds"]["points_per"] = rush_yds_pt
+        if "RushTD" in config.get(pos, {}):
+            config[pos]["RushTD"]["points"] = rush_td_pts
+    for pos in ("QB", "RB", "WR", "TE"):
+        if "Fum" in config.get(pos, {}):
+            config[pos]["Fum"]["points"] = fum_pen
+    for pos in ("RB", "WR", "TE"):
+        if "RecYds" in config.get(pos, {}):
+            config[pos]["RecYds"]["points_per"] = rec_yds_pt
+        if "Rec" in config.get(pos, {}):
+            config[pos]["Rec"]["points_per"] = rec_per
+        if "RecTD" in config.get(pos, {}):
+            config[pos]["RecTD"]["points"] = rec_td_pts
+
+    save_config(SETTINGS_PATH, config)
+    return config
+
+
+@callback(
+    Output("scoring-config", "data"),
+    Input("load-config", "n_clicks"),
+    prevent_initial_call=True,
+)
+def load_settings(n_clicks):
+    """Load scoring settings from disk into the store."""
+
+    return load_config(SETTINGS_PATH)
+
+
+@callback(
+    Output("pass-yds-pt", "value"),
+    Output("pass-td-pts", "value"),
+    Output("int-pen", "value"),
+    Output("rush-yds-pt", "value"),
+    Output("rush-td-pts", "value"),
+    Output("fum-pen", "value"),
+    Output("rec-yds-pt", "value"),
+    Output("rec-per", "value"),
+    Output("rec-td-pts", "value"),
+    Input("scoring-config", "data"),
+)
+def display_settings(config):
+    """Reflect current config values in the UI controls."""
+
+    cfg = config or SCORING_CONFIG_DEFAULT
+    return (
+        cfg["QB"]["PassYds"]["points_per"],
+        cfg["QB"]["PassTD"]["points"],
+        cfg["QB"]["Int"]["points"],
+        cfg["RB"]["RushYds"]["points_per"],
+        cfg["RB"]["RushTD"]["points"],
+        cfg["RB"]["Fum"]["points"],
+        cfg["RB"]["RecYds"]["points_per"],
+        cfg["RB"]["Rec"]["points_per"],
+        cfg["RB"]["RecTD"]["points"],
+    )

--- a/pages/modeling_dashboard.py
+++ b/pages/modeling_dashboard.py
@@ -1,13 +1,13 @@
 import dash
-from dash import html, dcc, Input, Output, callback
+from dash import html, dcc, Input, Output, callback, State
 from dash_ag_grid import AgGrid
 import dash_bootstrap_components as dbc
 from copy import deepcopy
 
-from layout import create_scoring_controls
 from utility.helpers import get_offense_data, clean_offense_data
 from modeling.predict import predict_position
-from utility.scoring import SCORING_CONFIG_DEFAULT, calculate_prop_points
+from utility.scoring import SCORING_CONFIG_DEFAULT, calculate_prop_points, load_config
+from pathlib import Path
 
 # Register page
 
@@ -20,18 +20,7 @@ _positions = sorted(_base_df["Position"].dropna().unique())
 _teams = sorted(_base_df["Team"].dropna().unique())
 
 
-def _compute_projections(
-    df,
-    pass_yds_pt=25,
-    pass_td_pts=6,
-    int_pen=-3,
-    rush_yds_pt=10,
-    rush_td_pts=6,
-    fum_pen=-3,
-    rec_yds_pt=10,
-    rec_per=5,
-    rec_td_pts=6,
-):
+def _compute_projections(df, config=None):
     df = df.copy()
 
     # Add model projections for each position
@@ -43,54 +32,21 @@ def _compute_projections(
         except Exception:
             df.loc[pos_df.index, "Projection"] = 0.0
 
-    # Build scoring configuration
-    config = deepcopy(SCORING_CONFIG_DEFAULT)
-    if pass_yds_pt is not None:
-        config["QB"]["PassYds"]["points_per"] = pass_yds_pt
-    if pass_td_pts is not None:
-        config["QB"]["PassTD"]["points"] = pass_td_pts
-    if int_pen is not None:
-        config["QB"]["Int"]["points"] = int_pen
-    if rush_yds_pt is not None:
-        for pos in ("QB", "RB", "WR"):
-            if "RushYds" in config.get(pos, {}):
-                config[pos]["RushYds"]["points_per"] = rush_yds_pt
-    if rush_td_pts is not None:
-        for pos in ("QB", "RB", "WR"):
-            if "RushTD" in config.get(pos, {}):
-                config[pos]["RushTD"]["points"] = rush_td_pts
-    if fum_pen is not None:
-        for pos in ("QB", "RB", "WR", "TE"):
-            if "Fum" in config.get(pos, {}):
-                config[pos]["Fum"]["points"] = fum_pen
-    if rec_yds_pt is not None:
-        for pos in ("RB", "WR", "TE"):
-            if "RecYds" in config.get(pos, {}):
-                config[pos]["RecYds"]["points_per"] = rec_yds_pt
-    if rec_per is not None:
-        for pos in ("RB", "WR", "TE"):
-            if "Rec" in config.get(pos, {}):
-                config[pos]["Rec"]["points_per"] = rec_per
-    if rec_td_pts is not None:
-        for pos in ("RB", "WR", "TE"):
-            if "RecTD" in config.get(pos, {}):
-                config[pos]["RecTD"]["points"] = rec_td_pts
-
+    cfg = config or deepcopy(SCORING_CONFIG_DEFAULT)
     scoring_df = df.rename(columns={"Position": "Pos"})
-    scoring_df = calculate_prop_points(scoring_df, config=config)
+    scoring_df = calculate_prop_points(scoring_df, config=cfg)
     df["FantasyPoints"] = scoring_df["ModelPoints"]
 
     return df
 
 
 def layout():
-    scoring_controls = create_scoring_controls()
-    initial_df = _compute_projections(_base_df)
+    initial_cfg = load_config(Path("assets/settings.json"))
+    initial_df = _compute_projections(_base_df, config=initial_cfg)
 
     return dbc.Container(
         [
             html.H1("Modeling Dashboard"),
-            scoring_controls,
             dbc.Row(
                 [
                     dbc.Col(
@@ -147,45 +103,11 @@ def layout():
 
 @callback(
     Output("model-grid", "rowData"),
-    [
-        Input("model-pos-filter", "value"),
-        Input("model-team-filter", "value"),
-        Input("pass-yds-pt", "value"),
-        Input("pass-td-pts", "value"),
-        Input("int-pen", "value"),
-        Input("rush-yds-pt", "value"),
-        Input("rush-td-pts", "value"),
-        Input("fum-pen", "value"),
-        Input("rec-yds-pt", "value"),
-        Input("rec-per", "value"),
-        Input("rec-td-pts", "value"),
-    ],
+    [Input("model-pos-filter", "value"), Input("model-team-filter", "value")],
+    State("scoring-config", "data"),
 )
-def update_grid(
-    pos_filter,
-    team_filter,
-    pass_yds_pt,
-    pass_td_pts,
-    int_pen,
-    rush_yds_pt,
-    rush_td_pts,
-    fum_pen,
-    rec_yds_pt,
-    rec_per,
-    rec_td_pts,
-):
-    df = _compute_projections(
-        _base_df,
-        pass_yds_pt,
-        pass_td_pts,
-        int_pen,
-        rush_yds_pt,
-        rush_td_pts,
-        fum_pen,
-        rec_yds_pt,
-        rec_per,
-        rec_td_pts,
-    )
+def update_grid(pos_filter, team_filter, config):
+    df = _compute_projections(_base_df, config=config)
 
     if pos_filter:
         df = df[df["Position"].isin(pos_filter)]

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utility.scoring import save_config, load_config, SCORING_CONFIG_DEFAULT
+
+
+def test_save_load_round_trip(tmp_path):
+    path = tmp_path / "config.json"
+    config = {"QB": {"PassTD": {"points": 4}}}
+    save_config(path, config)
+    assert load_config(path) == config
+
+
+def test_load_config_default(tmp_path):
+    path = tmp_path / "missing.json"
+    loaded = load_config(path)
+    assert loaded == SCORING_CONFIG_DEFAULT
+    assert loaded is not SCORING_CONFIG_DEFAULT

--- a/utility/scoring.py
+++ b/utility/scoring.py
@@ -1,3 +1,5 @@
+import json
+from copy import deepcopy
 import pandas as pd
 from pathlib import Path
 
@@ -204,6 +206,43 @@ SCORING_CONFIG_DEFAULT = {
     'WR': RB_WR_SCORING_DEFAULT,
     'TE': TE_SCORING_DEFAULT,
 }
+
+
+def save_config(path: str | Path, config: dict) -> None:
+    """Serialize a scoring configuration to JSON.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+    config:
+        Scoring configuration mapping to persist.
+    """
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('w', encoding='utf-8') as f:
+        json.dump(config, f, indent=2)
+
+
+def load_config(path: str | Path) -> dict:
+    """Load a scoring configuration from JSON.
+
+    If the file does not exist or cannot be parsed, a deep copy of
+    :data:`SCORING_CONFIG_DEFAULT` is returned.
+    """
+
+    path = Path(path)
+    if not path.exists():
+        return deepcopy(SCORING_CONFIG_DEFAULT)
+    try:
+        with path.open(encoding='utf-8') as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return deepcopy(SCORING_CONFIG_DEFAULT)
 
 
 def calculate_prop_points(df: pd.DataFrame, config: dict | None = None) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- create league settings page with scoring controls
- persist scoring config to assets/settings.json
- consume shared scoring settings across projections and modeling

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a52d9e66a883229d88380ab264060d