### PR TITLE
Add configurable league settings for auction calculations

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,10 +9,13 @@ from utility import scoring
 from utility.scoring import load_config
 from models.auction import (
     all_players_sorted,
-    NUM_TEAMS,
     compute_values,
-    INITIAL_BUDGET,
 )
+
+settings_path = Path("assets/settings.json")
+initial_settings = load_config(settings_path)
+NUM_TEAMS = initial_settings.get('league', {}).get('num_teams', 12)
+INITIAL_BUDGET = initial_settings.get('league', {}).get('initial_budget', 200)
 
 draft_history = []
 
@@ -28,7 +31,7 @@ server = app.server
 
 app.layout = dbc.Container(
     [
-        dcc.Store(id="scoring-config", data=load_config(Path("assets/settings.json"))),
+        dcc.Store(id="scoring-config", data=initial_settings),
         dbc.NavbarSimple(
             children=[
                 dbc.NavItem(dbc.NavLink("Home", href="/")),
@@ -59,12 +62,7 @@ app.layout = dbc.Container(
 )
 def update_player_data(config, current_data):
     cfg = config or scoring.SCORING_CONFIG_DEFAULT
-    compute_cfg = {
-        'QB': cfg.get('QB', scoring.QB_SCORING_DEFAULT),
-        'RB_WR': cfg.get('RB', scoring.RB_WR_SCORING_DEFAULT),
-        'TE': cfg.get('TE', scoring.TE_SCORING_DEFAULT),
-    }
-    new_players = compute_values(compute_cfg)
+    new_players = compute_values(cfg)
     if current_data:
         drafted_cols = pd.DataFrame(current_data)[['Name', 'Drafted', 'DraftedBy', 'PricePaid']]
         new_players = new_players.merge(drafted_cols, on='Name', how='left')

--- a/assets/settings.json
+++ b/assets/settings.json
@@ -1,4 +1,8 @@
 {
+  "league": {
+    "num_teams": 12,
+    "initial_budget": 200
+  },
   "QB": {
     "PassYds": {"points_per": 25, "bonuses": {"250": 3, "350": 3, "450": 3, "550": 3, "650": 3}},
     "PassTD": {"points": 6},

--- a/pages/auction.py
+++ b/pages/auction.py
@@ -1,9 +1,14 @@
 import dash
+from pathlib import Path
 from layout import create_layout
-from models.auction import all_players_sorted, NUM_TEAMS
+from models.auction import all_players_sorted
+from utility.scoring import load_config
 
 
 dash.register_page(__name__, path='/auction')
+
+settings = load_config(Path("assets/settings.json"))
+NUM_TEAMS = settings.get('league', {}).get('num_teams', 12)
 
 layout = create_layout(
     all_players_sorted['Name'].tolist(),

--- a/pages/league_settings.py
+++ b/pages/league_settings.py
@@ -22,6 +22,22 @@ def layout():
     return dbc.Container(
         [
             html.H1("League Settings"),
+            html.Div(
+                [
+                    html.H4("League Settings"),
+                    dbc.Row([
+                        dbc.Col([
+                            dbc.Label("Number of Teams"),
+                            dcc.Input(id='num-teams', type='number', value=12, className="form-control"),
+                        ], xs=12, sm=6, md=4),
+                        dbc.Col([
+                            dbc.Label("Initial Budget"),
+                            dcc.Input(id='initial-budget', type='number', value=200, className="form-control"),
+                        ], xs=12, sm=6, md=4),
+                    ], className="g-2"),
+                ],
+                className="mb-4",
+            ),
             create_scoring_controls(),
             dbc.Button("Save", id="save-config", color="primary", className="me-2"),
             dbc.Button("Load", id="load-config", color="secondary"),
@@ -33,6 +49,8 @@ def layout():
 @callback(
     Output("scoring-config", "data"),
     Input("save-config", "n_clicks"),
+    State("num-teams", "value"),
+    State("initial-budget", "value"),
     State("pass-yds-pt", "value"),
     State("pass-td-pts", "value"),
     State("int-pen", "value"),
@@ -44,11 +62,13 @@ def layout():
     State("rec-td-pts", "value"),
     prevent_initial_call=True,
 )
-def save_settings(n_clicks, pass_yds_pt, pass_td_pts, int_pen, rush_yds_pt, rush_td_pts,
-                  fum_pen, rec_yds_pt, rec_per, rec_td_pts):
+def save_settings(n_clicks, num_teams, initial_budget, pass_yds_pt, pass_td_pts, int_pen,
+                  rush_yds_pt, rush_td_pts, fum_pen, rec_yds_pt, rec_per, rec_td_pts):
     """Persist scoring settings and update the store."""
 
     config = deepcopy(SCORING_CONFIG_DEFAULT)
+    config["league"]["num_teams"] = num_teams
+    config["league"]["initial_budget"] = initial_budget
     config["QB"]["PassYds"]["points_per"] = pass_yds_pt
     config["QB"]["PassTD"]["points"] = pass_td_pts
     config["QB"]["Int"]["points"] = int_pen
@@ -84,6 +104,8 @@ def load_settings(n_clicks):
 
 
 @callback(
+    Output("num-teams", "value"),
+    Output("initial-budget", "value"),
     Output("pass-yds-pt", "value"),
     Output("pass-td-pts", "value"),
     Output("int-pen", "value"),
@@ -100,6 +122,8 @@ def display_settings(config):
 
     cfg = config or SCORING_CONFIG_DEFAULT
     return (
+        cfg["league"]["num_teams"],
+        cfg["league"]["initial_budget"],
         cfg["QB"]["PassYds"]["points_per"],
         cfg["QB"]["PassTD"]["points"],
         cfg["QB"]["Int"]["points"],

--- a/tests/test_auction_settings.py
+++ b/tests/test_auction_settings.py
@@ -1,0 +1,47 @@
+import pytest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from models.auction import compute_values
+from utility import scoring
+
+
+def _base_config(num_teams=12, budget=200):
+    return {
+        'league': {'num_teams': num_teams, 'initial_budget': budget},
+        'QB': scoring.QB_SCORING_DEFAULT,
+        'RB': scoring.RB_WR_SCORING_DEFAULT,
+        'WR': scoring.RB_WR_SCORING_DEFAULT,
+        'TE': scoring.TE_SCORING_DEFAULT,
+    }
+
+
+def test_values_scale_with_num_teams():
+    cfg_default = _base_config(num_teams=12, budget=200)
+    cfg_half = _base_config(num_teams=6, budget=200)
+
+    df_default = compute_values(cfg_default)
+    df_half = compute_values(cfg_half)
+
+    player = df_default.iloc[0]['Name']
+    val_default = df_default[df_default['Name'] == player]['AuctionValue'].iloc[0]
+    val_half = df_half[df_half['Name'] == player]['AuctionValue'].iloc[0]
+
+    assert val_half == pytest.approx(val_default * 0.5, rel=1e-6)
+
+
+def test_values_scale_with_budget():
+    cfg_default = _base_config(num_teams=12, budget=200)
+    cfg_low_budget = _base_config(num_teams=12, budget=100)
+
+    df_default = compute_values(cfg_default)
+    df_low = compute_values(cfg_low_budget)
+
+    player = df_default.iloc[0]['Name']
+    val_default = df_default[df_default['Name'] == player]['AuctionValue'].iloc[0]
+    val_low = df_low[df_low['Name'] == player]['AuctionValue'].iloc[0]
+
+    expected_ratio = (12 * 100 - 12 * 17) / (12 * 200 - 12 * 17)
+    assert val_low == pytest.approx(val_default * expected_ratio, rel=1e-6)

--- a/utility/scoring.py
+++ b/utility/scoring.py
@@ -12,6 +12,11 @@ for df in (qb_adv_stats, rb_adv_stats, wr_adv_stats):
     if 'Player' in df.columns:
         df['Player'] = df['Player'].str.replace(r'[^\w\s]', '', regex=True)
 
+LEAGUE_SETTINGS_DEFAULT = {
+    'num_teams': 12,
+    'initial_budget': 200,
+}
+
 QB_SCORING_DEFAULT = {
     'PassYds': {'points_per': 25, 'bonuses': {250: 3, 350: 3, 450: 3, 550: 3, 650: 3}},
     'PassTD': {'points': 6},
@@ -225,6 +230,7 @@ def calculate_te_points(row, config=TE_SCORING_DEFAULT):
 
 
 SCORING_CONFIG_DEFAULT = {
+    'league': LEAGUE_SETTINGS_DEFAULT,
     'QB': QB_SCORING_DEFAULT,
     'RB': RB_WR_SCORING_DEFAULT,
     'WR': RB_WR_SCORING_DEFAULT,


### PR DESCRIPTION
## Summary
- extend settings to store league size and budgets
- compute auction values using league settings and expose editing via League Settings page
- add tests verifying auction value scaling with custom configurations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a52f8b3310832288e3ac9a3a5da8d4