### PR TITLE
Load team names from settings for draftboard

### DIFF
--- a/pages/draftboard.py
+++ b/pages/draftboard.py
@@ -3,11 +3,16 @@ from dash import dcc, html, Input, Output, State, callback
 from dash_ag_grid import AgGrid
 import pandas as pd
 from utility import helpers
+from utility.scoring import load_config
+from pathlib import Path
 from datetime import datetime
 import time
 
 
 dash.register_page(__name__, path='/draftboard')
+
+settings = load_config(Path("assets/settings.json"))
+TEAM_NAMES = settings.get('league', {}).get('team_names', [])
 
 board_df = helpers.get_board()
 board_df = helpers.clean_board(board_df)
@@ -51,7 +56,7 @@ def layout():
                     'field': 'Owner',
                     'editable': True,
                     'cellEditor': 'agSelectCellEditor',
-                    'cellEditorParams': {'values': ['Bob', 'Josh', 'Joe']},
+                    'cellEditorParams': {'values': TEAM_NAMES},
                     'filter': True,
                     'sortable': True,
                 },

--- a/tests/test_team_names.py
+++ b/tests/test_team_names.py
@@ -1,10 +1,16 @@
 import sys
 import pathlib
 from copy import deepcopy
+import importlib
+
+import pandas as pd
+from dash_ag_grid import AgGrid
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from utility.scoring import save_config, load_config, SCORING_CONFIG_DEFAULT
+import utility.scoring as scoring
+from utility import helpers
 import app
 
 
@@ -37,3 +43,46 @@ def test_team_names_in_summary(monkeypatch):
     chart_start = 3 + 2 * len(app.TEAM_NAMES)
     team_chart = outputs[chart_start]
     assert team_chart.layout.title.text == 'Alpha Composition'
+
+
+def test_draftboard_owner_dropdown_uses_config_names(monkeypatch):
+    mock_settings = {'league': {'team_names': ['Alpha', 'Beta']}}
+    monkeypatch.setattr(scoring, 'load_config', lambda path: mock_settings)
+
+    board = pd.DataFrame({
+        'Name': ['Player1'],
+        'Position': ['QB'],
+        'Team': ['NE'],
+        'Owner': [''],
+        'Price': [0],
+    })
+
+    monkeypatch.setattr(helpers, 'get_board', lambda: board)
+    monkeypatch.setattr(helpers, 'clean_board', lambda df: df)
+
+    draftboard = importlib.reload(importlib.import_module('pages.draftboard'))
+    component = draftboard.layout()
+    grid = next(child for child in component.children if isinstance(child, AgGrid))
+    owner_column = next(col for col in grid.columnDefs if col.get('field') == 'Owner')
+    assert owner_column['cellEditorParams']['values'] == ['Alpha', 'Beta']
+
+
+def test_saved_board_maps_players_to_correct_teams(tmp_path, monkeypatch):
+    fake_module_path = tmp_path / 'utility' / 'helpers.py'
+    fake_module_path.parent.mkdir(parents=True)
+    fake_module_path.write_text('')
+    monkeypatch.setattr(helpers, '__file__', str(fake_module_path))
+    (tmp_path / 'data').mkdir()
+
+    df = pd.DataFrame({
+        'Name': ['Player1'],
+        'Position': ['QB'],
+        'Team': ['NE'],
+        'Owner': ['Alpha'],
+        'Price': [10],
+    })
+
+    df.to_csv(tmp_path / 'data' / 'board.csv', index=False)
+    loaded = helpers.get_board()
+    cleaned = helpers.clean_board(loaded)
+    assert cleaned.loc[0, 'Owner'] == 'Alpha'


### PR DESCRIPTION
## Summary
- Dynamically load team names from assets/settings.json and populate the draft board owner dropdown
- Add tests ensuring draft board owner options pull from config and saved boards retain owner-team mappings

## Testing
- ⚠️ `pip install pandas dash-ag-grid -q` (failed: Could not connect to proxy)
- ⚠️ `pytest -q` (failed: No module named 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_68a53387b80c8322b88339e66a6fee43