### PR TITLE
Handle duplicate scoring-config updates in settings page

### DIFF
--- a/pages/league_settings.py
+++ b/pages/league_settings.py
@@ -121,7 +121,7 @@ def save_settings(n_clicks, num_teams, initial_budget, team_names, pass_yds_pt, 
 
 
 @callback(
-    Output("scoring-config", "data"),
+    Output("scoring-config", "data", allow_duplicate=True),
     Input("load-config", "n_clicks"),
     prevent_initial_call=True,
 )


### PR DESCRIPTION
## Summary
- prevent Dash `Duplicate callback outputs` error by allowing duplicate updates to `scoring-config` store when loading settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a670f79d548322a1c8efe2e1bb6f3d